### PR TITLE
Add 'status_requested' event type to models

### DIFF
--- a/pysnoo/models.py
+++ b/pysnoo/models.py
@@ -631,6 +631,7 @@ class EventType(Enum):
     TIMER = 'timer'
     COMMAND = 'command'
     SAFETY_CLIP = 'safety_clip'
+    STATUS_REQUESTED = 'status_requested'
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
The `snoo history` command was broken due to a missing event type. This PR adds that event type.

Ran against current test suite.